### PR TITLE
Fix crashing on incorrect templates

### DIFF
--- a/src/Phug/WatcherExtension.php
+++ b/src/Phug/WatcherExtension.php
@@ -53,8 +53,11 @@ class WatcherExtension extends AbstractExtension
 
         $watcher->setChangeEventCallback(function ($event, $resource, $path) {
             if (file_exists($path)) {
+                $sadbox = Phug::getRenderer()->getNewSandBox(function () use ($path) {
+                    return Phug::cacheFile($path);
+                });
                 echo "Changes detected in $path\n";
-                echo ' - '.(Phug::cacheFile($path)
+                echo ' - '.($sadbox->getResult()
                         ? 'template cached successfully'
                         : 'cache failure'
                     )."\n";

--- a/src/Phug/WatcherExtension.php
+++ b/src/Phug/WatcherExtension.php
@@ -53,11 +53,12 @@ class WatcherExtension extends AbstractExtension
 
         $watcher->setChangeEventCallback(function ($event, $resource, $path) {
             if (file_exists($path)) {
-                $sadbox = Phug::getRenderer()->getNewSandBox(function () use ($path) {
+                $sandbox = Phug::getRenderer()->getNewSandBox(function () use ($path) {
                     return Phug::cacheFile($path);
                 });
+
                 echo "Changes detected in $path\n";
-                echo ' - '.($sadbox->getResult()
+                echo ' - '.($sandbox->getResult()
                         ? 'template cached successfully'
                         : 'cache failure'
                     )."\n";


### PR DESCRIPTION
Watcher crashes if pug file has an error, for example:
```pug
+testMixin$arg) // missing bracket
```
